### PR TITLE
Deprecate gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # Citywrapper
 [![Build Status](https://travis-ci.org/JoeSouthan/citywrapper.svg?branch=master)](https://travis-ci.org/JoeSouthan/citywrapper)
 [![Code Climate](https://codeclimate.com/github/JoeSouthan/citywrapper/badges/gpa.svg)](https://codeclimate.com/github/JoeSouthan/citywrapper)
-#### WIP
-
-TODO:
-- Better documentation
 
 A very light wrapper around the [Citymapper API](https://citymapper.3scale.net/).
+# 🚨 Deprecation/Archival 🚨
 
-This is in very early development, the Ruby API may change drastically.
+Citymapper have [deprecated](https://citymapper.3scale.net/docs) this API. There will be no further updates to this gem.
 
 ## Installation
 

--- a/citywrapper.gemspec
+++ b/citywrapper.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'citywrapper'
   spec.version       = Citywrapper::VERSION
   spec.authors       = ['Joseph Southan']
-  spec.email         = ['joe+github@sthn.io']
+  spec.email         = ['gems@sthn.io']
 
   spec.summary       = 'Wraps the Citymapper API'
   spec.description   = 'Simple wrapper around the Citymapper API'
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.15'
   spec.add_development_dependency 'vcr', '~> 6'
   spec.add_development_dependency 'webmock', '~> 3.1'
+
+  spec.post_install_message = "The Citymaper APIs are now deprecated and will likely not work in the future"
 end

--- a/lib/citywrapper.rb
+++ b/lib/citywrapper.rb
@@ -20,6 +20,7 @@ module Citywrapper
   end
 
   def self.configuration
+    warn "NOTE: Citymaper APIs are now deprecated and will likely not work in the future"
     @configuration ||= Configuration.new
   end
 

--- a/lib/citywrapper/api_base.rb
+++ b/lib/citywrapper/api_base.rb
@@ -11,6 +11,7 @@ module Citywrapper
 
     def initialize
       @config = Citywrapper.configuration
+      warn "NOTE: #{self.class} is deprecated and will likely not work in the future"
     end
 
     def request(params: {}, method: :get)

--- a/lib/citywrapper/version.rb
+++ b/lib/citywrapper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Citywrapper
-  VERSION = "0.1.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Citymapper have [deprecated](https://citymapper.3scale.net/docs) this API. There will be no further updates to this gem.
